### PR TITLE
Add Linux aarch64 packages

### DIFF
--- a/.github/workflows/build_publish_package.yml
+++ b/.github/workflows/build_publish_package.yml
@@ -44,13 +44,22 @@ jobs:
         auto-update-conda: true
         miniforge-version: latest
 
-    - name: Install miniconda [Linux & macOS]
-      if: contains(inputs.runner, 'windows') == false
+    - name: Install miniconda [Linux x64 & macOS]
+      if: contains(inputs.runner, 'windows') == false && !(contains(inputs.runner, 'ubuntu') && contains(inputs.runner, 'arm'))
       uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: sofa-conda-ci
         auto-update-conda: true
         miniforge-version: latest
+
+    - name: Install miniconda [Linux aarch64]
+      if: contains(inputs.runner, 'ubuntu') && contains(inputs.runner, 'arm')
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: sofa-conda-ci
+        auto-update-conda: true
+        miniforge-version: latest
+        architecture: aarch64
 
     - name: Install conda environment
       shell: bash -l {0}

--- a/.github/workflows/build_publish_package.yml
+++ b/.github/workflows/build_publish_package.yml
@@ -30,6 +30,12 @@ jobs:
     name: "Build and publish  ${{ inputs.package-name }} - ${{ inputs.platform }} (py${{ inputs.python }} ) conda packages on ${{ inputs.runner }}"
     runs-on: ${{ inputs.runner }}
     steps:
+    # hotfix for linux arm64 runners that have a permission bug
+    # https://github.com/orgs/community/discussions/148648#discussioncomment-11858098
+    - name: Fix PATH and XDG_CONFIG_HOME for ARM64 Linux runners (actions/partner-runner-images#25)
+      if: contains(inputs.runner, 'ubuntu') && contains(inputs.runner, 'arm')
+      run: for var in PATH XDG_CONFIG_HOME; do sed -Ee "s/^/${var}=/" -e 's/(runner)admin/\1/g' <<< "${!var}"; done | tee -a "$GITHUB_ENV"
+
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/nightly-sofa-beamadapter.yml
+++ b/.github/workflows/nightly-sofa-beamadapter.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                  {platform: "osx-64", runner: "macos-13"},
                  {platform: "osx-arm64", runner: "macos-14"},
                  {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa-cosserat.yml
+++ b/.github/workflows/nightly-sofa-cosserat.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                   {platform: "osx-64", runner: "macos-13"},
                   {platform: "osx-arm64", runner: "macos-14"},
                   {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa-modelorderreduction.yml
+++ b/.github/workflows/nightly-sofa-modelorderreduction.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                   {platform: "osx-64", runner: "macos-13"},
                   {platform: "osx-arm64", runner: "macos-14"},
                   {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa-python3.yml
+++ b/.github/workflows/nightly-sofa-python3.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                   {platform: "osx-64", runner: "macos-13"},
                   {platform: "osx-arm64", runner: "macos-14"},
                   {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa-softrobots.yml
+++ b/.github/workflows/nightly-sofa-softrobots.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                   {platform: "osx-64", runner: "macos-13"},
                   {platform: "osx-arm64", runner: "macos-14"},
                   {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa-stlib.yml
+++ b/.github/workflows/nightly-sofa-stlib.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                   {platform: "osx-64", runner: "macos-13"},
                   {platform: "osx-arm64", runner: "macos-14"},
                   {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/nightly-sofa.yml
+++ b/.github/workflows/nightly-sofa.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                  {platform: "osx-64", runner: "macos-13"},
                  {platform: "osx-arm64", runner: "macos-14"},
                  {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/sofa-beamadapter.yml
+++ b/.github/workflows/sofa-beamadapter.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
 
     uses: ./.github/workflows/build_publish_package.yml
     with:

--- a/.github/workflows/sofa-beamadapter.yml
+++ b/.github/workflows/sofa-beamadapter.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                 {platform: "osx-64", runner: "macos-13"},
-                 {platform: "osx-arm64", runner: "macos-14"},
-                 {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
 
     uses: ./.github/workflows/build_publish_package.yml
     with:

--- a/.github/workflows/sofa-cosserat.yml
+++ b/.github/workflows/sofa-cosserat.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                  {platform: "osx-64", runner: "macos-13"},
-                  {platform: "osx-arm64", runner: "macos-14"},
-                  {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-cosserat.yml
+++ b/.github/workflows/sofa-cosserat.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-modelorderreduction.yml
+++ b/.github/workflows/sofa-modelorderreduction.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                  {platform: "osx-64", runner: "macos-13"},
-                  {platform: "osx-arm64", runner: "macos-14"},
-                  {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-modelorderreduction.yml
+++ b/.github/workflows/sofa-modelorderreduction.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-python3.yml
+++ b/.github/workflows/sofa-python3.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                  {platform: "osx-64", runner: "macos-13"},
-                  {platform: "osx-arm64", runner: "macos-14"},
-                  {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-python3.yml
+++ b/.github/workflows/sofa-python3.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-softrobots.yml
+++ b/.github/workflows/sofa-softrobots.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                  {platform: "osx-64", runner: "macos-13"},
-                  {platform: "osx-arm64", runner: "macos-14"},
-                  {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-softrobots.yml
+++ b/.github/workflows/sofa-softrobots.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-stlib.yml
+++ b/.github/workflows/sofa-stlib.yml
@@ -8,10 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                  {platform: "osx-64", runner: "macos-13"},
-                  {platform: "osx-arm64", runner: "macos-14"},
-                  {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa-stlib.yml
+++ b/.github/workflows/sofa-stlib.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_publish_package.yml

--- a/.github/workflows/sofa.yml
+++ b/.github/workflows/sofa.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
                  {platform: "osx-64", runner: "macos-13"},
                  {platform: "osx-arm64", runner: "macos-14"},
                  {platform: "win-64", runner: "windows-latest"}]

--- a/.github/workflows/sofa.yml
+++ b/.github/workflows/sofa.yml
@@ -8,12 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
-        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-        #          {platform: "osx-64", runner: "macos-13"},
-        #          {platform: "osx-arm64", runner: "macos-14"},
-        #          {platform: "win-64", runner: "windows-latest"}]
-        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
+        target: [{platform: "linux-64", runner: "ubuntu-latest"},
+                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+                 {platform: "osx-64", runner: "macos-13"},
+                 {platform: "osx-arm64", runner: "macos-14"},
+                 {platform: "win-64", runner: "windows-latest"}]
 
     uses: ./.github/workflows/build_publish_package.yml
     with:

--- a/.github/workflows/sofa.yml
+++ b/.github/workflows/sofa.yml
@@ -8,11 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [{platform: "linux-64", runner: "ubuntu-latest"},
-                 {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
-                 {platform: "osx-64", runner: "macos-13"},
-                 {platform: "osx-arm64", runner: "macos-14"},
-                 {platform: "win-64", runner: "windows-latest"}]
+        # target: [{platform: "linux-64", runner: "ubuntu-latest"},
+        #          {platform: "linux-aarch64", runner: "ubuntu-22.04-arm"},
+        #          {platform: "osx-64", runner: "macos-13"},
+        #          {platform: "osx-arm64", runner: "macos-14"},
+        #          {platform: "win-64", runner: "windows-latest"}]
+        target: [{platform: "linux-aarch64", runner: "ubuntu-22.04-arm"}]
 
     uses: ./.github/workflows/build_publish_package.yml
     with:

--- a/conda/configs/linux-aarch64.yaml
+++ b/conda/configs/linux-aarch64.yaml
@@ -1,0 +1,12 @@
+c_stdlib_version:
+- '2.17'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+target_platform:
+- linux-aarch64

--- a/conda/recipes/nightly/sofa-python3/recipe.yaml
+++ b/conda/recipes/nightly/sofa-python3/recipe.yaml
@@ -51,7 +51,9 @@ requirements:
   host:
     - sofa-devel ==${{ version }}
     - sofa-gl ==${{ version }}
-    - sofa-gui-qt ==${{ version }}
+    - if: not(linux and aarch64)
+      then:
+        - sofa-gui-qt ==${{ version }}
     - eigen
     - libboost-headers
     - glew
@@ -64,7 +66,9 @@ requirements:
     # we manually pin compatibility between sofa libs and plugins to MAJOR.MINOR versions
     - ${{ pin_compatible('sofa-devel', lower_bound='x.x', upper_bound='x.x') }}
     - ${{ pin_compatible('sofa-gl', lower_bound='x.x', upper_bound='x.x') }}
-    - ${{ pin_compatible('sofa-gui-qt', lower_bound='x.x', upper_bound='x.x') }}
+    - if: not(linux and aarch64)
+      then:
+        - ${{ pin_compatible('sofa-gui-qt', lower_bound='x.x', upper_bound='x.x') }}
     - ${{ pin_compatible('numpy') }}
     - python
   run_exports:

--- a/conda/recipes/nightly/sofa/recipe.yaml
+++ b/conda/recipes/nightly/sofa/recipe.yaml
@@ -158,6 +158,8 @@ outputs:
       name: sofa-gui-qt
     build:
       script: scripts/build-sofa-gui-qt
+      skip:
+        - linux and aarch64
     requirements:
       build:
         - ${{ compiler('cxx') }}
@@ -224,13 +226,17 @@ outputs:
           then: ninja
       host:
         - ${{ pin_subpackage('sofa-devel', exact=True) }}
-        - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
+        - if: not(linux and aarch64)
+          then:
+            - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
         - eigen
         - libboost-headers
         - cxxopts
       run:
         - ${{ pin_subpackage('libsofa', exact=True) }}
-        - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
+        - if: not(linux and aarch64)
+          then:
+          - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
     tests:
       - package_contents:
           bin:

--- a/conda/recipes/release-v24.12/sofa-beamadapter/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-beamadapter/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
       then: 
         - ${{ cdt('mesa-libgl-devel') }}
   host:
-    - sofa-devel ${{ major_minor }}
+    - sofa-devel ==${{ major_minor }}
     - eigen
     - libboost-headers
   run:

--- a/conda/recipes/release-v24.12/sofa-cosserat/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-cosserat/recipe.yaml
@@ -32,9 +32,9 @@ requirements:
       then: 
         - ${{ cdt('mesa-libgl-devel') }}
   host:
-    - sofa-devel ${{ major_minor }}
-    - sofa-stlib ${{ major_minor }}
-    - sofa-softrobots ${{ major_minor }}
+    - sofa-devel ==${{ major_minor }}
+    - sofa-stlib ==${{ major_minor }}
+    - sofa-softrobots ==${{ major_minor }}
     - eigen
     - libboost-headers
     - cxxopts

--- a/conda/recipes/release-v24.12/sofa-modelorderreduction/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-modelorderreduction/recipe.yaml
@@ -37,8 +37,8 @@ requirements:
         - cross-python_${{ target_platform }}
         - pybind11
   host:
-    - sofa-devel ${{ major_minor }}
-    - sofa-python3 ${{ major_minor }}
+    - sofa-devel ==${{ major_minor }}
+    - sofa-python3 ==${{ major_minor }}
     - eigen
     - libboost-headers
     - cxxopts

--- a/conda/recipes/release-v24.12/sofa-python3/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-python3/recipe.yaml
@@ -50,7 +50,9 @@ requirements:
   host:
     - sofa-devel ${{ major_minor }}
     - sofa-gl ${{ major_minor }}
-    - sofa-gui-qt ${{ major_minor }}
+    - if: not(linux and aarch64)
+      then:
+        - sofa-gui-qt ${{ major_minor }}
     - eigen
     - libboost-headers
     - glew
@@ -63,7 +65,9 @@ requirements:
     # we manually pin compatibility between sofa libs and plugins to MAJOR.MINOR versions
     - ${{ pin_compatible('sofa-devel', lower_bound='x.x', upper_bound='x.x') }}
     - ${{ pin_compatible('sofa-gl', lower_bound='x.x', upper_bound='x.x') }}
-    - ${{ pin_compatible('sofa-gui-qt', lower_bound='x.x', upper_bound='x.x') }}
+    - if: not(linux and aarch64)
+      then:
+        - ${{ pin_compatible('sofa-gui-qt', lower_bound='x.x', upper_bound='x.x') }}
     - ${{ pin_compatible('numpy') }}
     - python
   run_exports:

--- a/conda/recipes/release-v24.12/sofa-python3/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-python3/recipe.yaml
@@ -48,11 +48,11 @@ requirements:
         - numpy
         - pybind11
   host:
-    - sofa-devel ${{ major_minor }}
-    - sofa-gl ${{ major_minor }}
+    - sofa-devel ==${{ major_minor }}
+    - sofa-gl ==${{ major_minor }}
     - if: not(linux and aarch64)
       then:
-        - sofa-gui-qt ${{ major_minor }}
+        - sofa-gui-qt ==${{ major_minor }}
     - eigen
     - libboost-headers
     - glew

--- a/conda/recipes/release-v24.12/sofa-softrobots/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-softrobots/recipe.yaml
@@ -12,7 +12,7 @@ package:
 
 source:
   git: https://github.com/SofaDefrost/SoftRobots.git
-  branch: release-v24.12
+  tag: release-v24.12
 
 build:
   number: ${{ build_num }}

--- a/conda/recipes/release-v24.12/sofa-softrobots/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-softrobots/recipe.yaml
@@ -37,8 +37,8 @@ requirements:
         - cross-python_${{ target_platform }}
         - pybind11
   host:
-    - sofa-devel ${{ major_minor }}
-    - sofa-stlib ${{ major_minor }}
+    - sofa-devel ==${{ major_minor }}
+    - sofa-stlib ==${{ major_minor }}
     - eigen
     - libboost-headers
     - cxxopts

--- a/conda/recipes/release-v24.12/sofa-stlib/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa-stlib/recipe.yaml
@@ -34,7 +34,7 @@ requirements:
         - cross-python_${{ target_platform }}
         - pybind11
   host:
-    - sofa-python3 ${{ major_minor }}
+    - sofa-python3 ==${{ major_minor }}
     - eigen
     - libboost-headers
     - python

--- a/conda/recipes/release-v24.12/sofa/recipe.yaml
+++ b/conda/recipes/release-v24.12/sofa/recipe.yaml
@@ -157,6 +157,8 @@ outputs:
       name: sofa-gui-qt
     build:
       script: scripts/build-sofa-gui-qt
+      skip:
+        - linux and aarch64
     requirements:
       build:
         - ${{ compiler('cxx') }}
@@ -223,13 +225,17 @@ outputs:
           then: ninja
       host:
         - ${{ pin_subpackage('sofa-devel', exact=True) }}
-        - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
+        - if: not(linux and aarch64)
+          then:
+            - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
         - eigen
         - libboost-headers
         - cxxopts
       run:
         - ${{ pin_subpackage('libsofa', exact=True) }}
-        - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
+        - if: not(linux and aarch64)
+          then:
+          - ${{ pin_subpackage('sofa-gui-qt', exact=True) }}
     tests:
       - package_contents:
           bin:


### PR DESCRIPTION
`sofa-qt-gui` is not supported on Linux-aarch64 due to the lack of package for `libqglviewer` on this platform, but Qt GUI should be replaced soon by ImGui.